### PR TITLE
Added: Extend Vert.x event bus with `localRequest()` and `localPublis…

### DIFF
--- a/src/main/kotlin/io/sip3/commons/vertx/AbstractBootstrap.kt
+++ b/src/main/kotlin/io/sip3/commons/vertx/AbstractBootstrap.kt
@@ -42,14 +42,11 @@ import io.vertx.core.json.pointer.JsonPointer
 import io.vertx.kotlin.config.configRetrieverOptionsOf
 import io.vertx.kotlin.config.configStoreOptionsOf
 import io.vertx.kotlin.core.deploymentOptionsOf
-import io.vertx.kotlin.core.eventbus.deliveryOptionsOf
 import mu.KotlinLogging
 import org.reflections.ReflectionUtils
 import org.reflections.Reflections
 import java.time.Duration
 import kotlin.system.exitProcess
-
-val USE_LOCAL_CODEC = deliveryOptionsOf(codecName = "local", localOnly = true)
 
 open class AbstractBootstrap : AbstractVerticle() {
 

--- a/src/main/kotlin/io/sip3/commons/vertx/AbstractBootstrap.kt
+++ b/src/main/kotlin/io/sip3/commons/vertx/AbstractBootstrap.kt
@@ -42,11 +42,14 @@ import io.vertx.core.json.pointer.JsonPointer
 import io.vertx.kotlin.config.configRetrieverOptionsOf
 import io.vertx.kotlin.config.configStoreOptionsOf
 import io.vertx.kotlin.core.deploymentOptionsOf
+import io.vertx.kotlin.core.eventbus.deliveryOptionsOf
 import mu.KotlinLogging
 import org.reflections.ReflectionUtils
 import org.reflections.Reflections
 import java.time.Duration
 import kotlin.system.exitProcess
+
+val USE_LOCAL_CODEC = deliveryOptionsOf(codecName = "local", localOnly = true)
 
 open class AbstractBootstrap : AbstractVerticle() {
 

--- a/src/main/kotlin/io/sip3/commons/vertx/AbstractBootstrap.kt
+++ b/src/main/kotlin/io/sip3/commons/vertx/AbstractBootstrap.kt
@@ -30,6 +30,7 @@ import io.micrometer.statsd.StatsdMeterRegistry
 import io.sip3.commons.Routes
 import io.sip3.commons.vertx.annotations.ConditionalOnProperty
 import io.sip3.commons.vertx.annotations.Instance
+import io.sip3.commons.vertx.util.localPublish
 import io.sip3.commons.vertx.util.registerLocalCodec
 import io.vertx.config.ConfigRetriever
 import io.vertx.config.ConfigRetrieverOptions
@@ -41,7 +42,6 @@ import io.vertx.core.json.pointer.JsonPointer
 import io.vertx.kotlin.config.configRetrieverOptionsOf
 import io.vertx.kotlin.config.configStoreOptionsOf
 import io.vertx.kotlin.core.deploymentOptionsOf
-import io.vertx.kotlin.core.eventbus.deliveryOptionsOf
 import mu.KotlinLogging
 import org.reflections.ReflectionUtils
 import org.reflections.Reflections
@@ -51,11 +51,6 @@ import kotlin.system.exitProcess
 open class AbstractBootstrap : AbstractVerticle() {
 
     private val logger = KotlinLogging.logger {}
-
-    companion object {
-
-        val USE_LOCAL_CODEC = deliveryOptionsOf(codecName = "local", localOnly = true)
-    }
 
     open val configLocations = emptyList<String>()
 
@@ -79,7 +74,7 @@ open class AbstractBootstrap : AbstractVerticle() {
         configRetriever.listen { change ->
             val config = change.newConfiguration
             logger.info("Configuration changed:\n ${config.encodePrettily()}")
-            vertx.eventBus().publish(Routes.config_change, config, USE_LOCAL_CODEC)
+            vertx.eventBus().localPublish(Routes.config_change, config)
         }
     }
 

--- a/src/main/kotlin/io/sip3/commons/vertx/util/EventBusUtil.kt
+++ b/src/main/kotlin/io/sip3/commons/vertx/util/EventBusUtil.kt
@@ -16,7 +16,11 @@
 
 package io.sip3.commons.vertx.util
 
+import io.vertx.core.AsyncResult
+import io.vertx.core.Handler
+import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
+import io.vertx.core.eventbus.Message
 import io.vertx.core.eventbus.impl.EventBusImpl
 
 @Suppress("UNCHECKED_CAST")
@@ -29,4 +33,27 @@ fun EventBus.endpoints(): Set<String> {
 
         (handlerMapField.get(eventBus) as? Map<String, Any>)?.let { return it.keys }
     } ?: emptySet()
+}
+
+fun <T> EventBus.localRequest(address: String,
+                              message: Any,
+                              options: DeliveryOptions? = null,
+                              replyHandler: Handler<AsyncResult<Message<T>>>? = null) {
+    val deliveryOptions = options?.let { DeliveryOptions(options) } ?: DeliveryOptions()
+    deliveryOptions.apply {
+        codecName = "local"
+        isLocalOnly = true
+    }
+    request(address, message, deliveryOptions, replyHandler)
+}
+
+fun EventBus.localPublish(address: String,
+                              message: Any,
+                              options: DeliveryOptions? = null) {
+    val deliveryOptions = options?.let { DeliveryOptions(options) } ?: DeliveryOptions()
+    deliveryOptions.apply {
+        codecName = "local"
+        isLocalOnly = true
+    }
+    publish(address, message, deliveryOptions)
 }

--- a/src/main/kotlin/io/sip3/commons/vertx/util/EventBusUtil.kt
+++ b/src/main/kotlin/io/sip3/commons/vertx/util/EventBusUtil.kt
@@ -16,6 +16,7 @@
 
 package io.sip3.commons.vertx.util
 
+import io.sip3.commons.vertx.USE_LOCAL_CODEC
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
 import io.vertx.core.eventbus.DeliveryOptions
@@ -39,21 +40,19 @@ fun <T> EventBus.localRequest(address: String,
                               message: Any,
                               options: DeliveryOptions? = null,
                               replyHandler: Handler<AsyncResult<Message<T>>>? = null) {
-    val deliveryOptions = options?.let { DeliveryOptions(options) } ?: DeliveryOptions()
-    deliveryOptions.apply {
+    options?.apply {
         codecName = "local"
         isLocalOnly = true
     }
-    request(address, message, deliveryOptions, replyHandler)
+    request(address, message, options ?: USE_LOCAL_CODEC, replyHandler)
 }
 
 fun EventBus.localPublish(address: String,
-                              message: Any,
-                              options: DeliveryOptions? = null) {
-    val deliveryOptions = options?.let { DeliveryOptions(options) } ?: DeliveryOptions()
-    deliveryOptions.apply {
+                          message: Any,
+                          options: DeliveryOptions? = null) {
+    options?.apply {
         codecName = "local"
         isLocalOnly = true
     }
-    publish(address, message, deliveryOptions)
+    publish(address, message, options ?: USE_LOCAL_CODEC)
 }

--- a/src/main/kotlin/io/sip3/commons/vertx/util/EventBusUtil.kt
+++ b/src/main/kotlin/io/sip3/commons/vertx/util/EventBusUtil.kt
@@ -16,24 +16,18 @@
 
 package io.sip3.commons.vertx.util
 
-import io.sip3.commons.vertx.USE_LOCAL_CODEC
+import io.sip3.commons.vertx.util.EventBusUtil.USE_LOCAL_CODEC
 import io.vertx.core.AsyncResult
 import io.vertx.core.Handler
 import io.vertx.core.eventbus.DeliveryOptions
 import io.vertx.core.eventbus.EventBus
 import io.vertx.core.eventbus.Message
 import io.vertx.core.eventbus.impl.EventBusImpl
+import io.vertx.kotlin.core.eventbus.deliveryOptionsOf
 
-@Suppress("UNCHECKED_CAST")
-fun EventBus.endpoints(): Set<String> {
-    return (this as? EventBusImpl)?.let { eventBus ->
-        // Read protected `handlerMap` field
-        val handlerMapField = EventBusImpl::class.java
-                .getDeclaredField("handlerMap")
-        handlerMapField.isAccessible = true
+object EventBusUtil {
 
-        (handlerMapField.get(eventBus) as? Map<String, Any>)?.let { return it.keys }
-    } ?: emptySet()
+    val USE_LOCAL_CODEC = deliveryOptionsOf(codecName = "local", localOnly = true)
 }
 
 fun <T> EventBus.localRequest(address: String,
@@ -55,4 +49,16 @@ fun EventBus.localPublish(address: String,
         isLocalOnly = true
     }
     publish(address, message, options ?: USE_LOCAL_CODEC)
+}
+
+@Suppress("UNCHECKED_CAST")
+fun EventBus.endpoints(): Set<String> {
+    return (this as? EventBusImpl)?.let { eventBus ->
+        // Read protected `handlerMap` field
+        val handlerMapField = EventBusImpl::class.java
+                .getDeclaredField("handlerMap")
+        handlerMapField.isAccessible = true
+
+        (handlerMapField.get(eventBus) as? Map<String, Any>)?.let { return it.keys }
+    } ?: emptySet()
 }

--- a/src/test/kotlin/io/sip3/commons/vertx/util/EventBusUtilTest.kt
+++ b/src/test/kotlin/io/sip3/commons/vertx/util/EventBusUtilTest.kt
@@ -25,28 +25,6 @@ import java.math.BigDecimal
 class EventBusUtilTest : VertxTest() {
 
     @Test
-    fun `Define and test event bus endpoints`() {
-        runTest(
-                deploy = {
-                    vertx.eventBus().localConsumer<String>("test1") {}
-                    vertx.eventBus().localConsumer<String>("test2") {}
-                },
-                assert = {
-                    vertx.setPeriodic(100) {
-                        val endpoints = vertx.eventBus().endpoints()
-                        context.verify {
-                            if (endpoints.size == 2) {
-                                assertTrue(endpoints.contains("test1"))
-                                assertTrue(endpoints.contains("test2"))
-                                context.completeNow()
-                            }
-                        }
-                    }
-                }
-        )
-    }
-
-    @Test
     fun `Check 'localRequest()' method`() {
         val answer = BigDecimal(42)
         runTest(
@@ -77,6 +55,28 @@ class EventBusUtilTest : VertxTest() {
                             assertEquals(answer, asr.body())
                         }
                         context.completeNow()
+                    }
+                }
+        )
+    }
+
+    @Test
+    fun `Define and test event bus endpoints`() {
+        runTest(
+                deploy = {
+                    vertx.eventBus().localConsumer<String>("test1") {}
+                    vertx.eventBus().localConsumer<String>("test2") {}
+                },
+                assert = {
+                    vertx.setPeriodic(100) {
+                        val endpoints = vertx.eventBus().endpoints()
+                        context.verify {
+                            if (endpoints.size == 2) {
+                                assertTrue(endpoints.contains("test1"))
+                                assertTrue(endpoints.contains("test2"))
+                                context.completeNow()
+                            }
+                        }
                     }
                 }
         )

--- a/src/test/kotlin/io/sip3/commons/vertx/util/EventBusUtilTest.kt
+++ b/src/test/kotlin/io/sip3/commons/vertx/util/EventBusUtilTest.kt
@@ -17,8 +17,10 @@
 package io.sip3.commons.vertx.util
 
 import io.sip3.commons.vertx.test.VertxTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 class EventBusUtilTest : VertxTest() {
 
@@ -39,6 +41,42 @@ class EventBusUtilTest : VertxTest() {
                                 context.completeNow()
                             }
                         }
+                    }
+                }
+        )
+    }
+
+    @Test
+    fun `Check 'localRequest()' method`() {
+        val answer = BigDecimal(42)
+        runTest(
+                execute = {
+                    vertx.eventBus().localRequest<Any>("question", answer)
+                },
+                assert = {
+                    vertx.eventBus().localConsumer<BigDecimal>("question") { asr ->
+                        context.verify {
+                            assertEquals(answer, asr.body())
+                        }
+                        context.completeNow()
+                    }
+                }
+        )
+    }
+
+    @Test
+    fun `Check 'localPublish()' method`() {
+        val answer = BigDecimal(42)
+        runTest(
+                execute = {
+                    vertx.eventBus().localPublish("question", answer)
+                },
+                assert = {
+                    vertx.eventBus().localConsumer<BigDecimal>("question") { asr ->
+                        context.verify {
+                            assertEquals(answer, asr.body())
+                        }
+                        context.completeNow()
                     }
                 }
         )


### PR DESCRIPTION
…h()` methods