### PR TITLE
Added: `recorded` attribute to RTP Report Payload and RTP Header

### DIFF
--- a/src/main/kotlin/io/sip3/commons/domain/payload/RtpHeaderPayload.kt
+++ b/src/main/kotlin/io/sip3/commons/domain/payload/RtpHeaderPayload.kt
@@ -26,14 +26,16 @@ class RtpHeaderPayload : Encodable, Decodable {
     var timestamp: Long = 0
     var ssrc: Long = 0
     var marker: Boolean = false
+    var recorded: Boolean = false
 
     override fun encode(): ByteBuf {
-        return Unpooled.buffer(22).apply {
+        return Unpooled.buffer(23).apply {
             writeByte(payloadType.toInt())
             writeInt(sequenceNumber)
             writeLong(timestamp)
             writeLong(ssrc)
             writeBoolean(marker)
+            writeBoolean(recorded)
         }
     }
 
@@ -43,5 +45,6 @@ class RtpHeaderPayload : Encodable, Decodable {
         timestamp = buffer.readLong()
         ssrc = buffer.readLong()
         marker = buffer.readBoolean()
+        recorded = buffer.readBoolean()
     }
 }

--- a/src/main/kotlin/io/sip3/commons/domain/payload/RtpReportPayload.kt
+++ b/src/main/kotlin/io/sip3/commons/domain/payload/RtpReportPayload.kt
@@ -35,7 +35,7 @@ open class RtpReportPayload : Encodable, Decodable {
         const val TAG_SSRC = 3
         const val TAG_CALL_ID = 4
         const val TAG_CODEC_NAME = 5
-        const val TAG_CUMULATIVE = 6
+        const val TAG_RECORDED = 6
 
         const val TAG_EXPECTED_PACKET_COUNT = 11
         const val TAG_RECEIVED_PACKET_COUNT = 12
@@ -65,7 +65,7 @@ open class RtpReportPayload : Encodable, Decodable {
     var ssrc: Long = 0
     var callId: String? = null
     var codecName: String? = null
-    var cumulative = false
+    var recorded = false
 
     var expectedPacketCount: Int = 0
     var receivedPacketCount: Int = 0
@@ -99,7 +99,7 @@ open class RtpReportPayload : Encodable, Decodable {
             writeTlv(TAG_SSRC, ssrc)
             callId?.let { writeTlv(TAG_CALL_ID, it) }
             codecName?.let { writeTlv(TAG_CODEC_NAME, it) }
-            writeTlv(TAG_CUMULATIVE, cumulative)
+            writeTlv(TAG_RECORDED, recorded)
 
             writeTlv(TAG_EXPECTED_PACKET_COUNT, expectedPacketCount)
             writeTlv(TAG_RECEIVED_PACKET_COUNT, receivedPacketCount)
@@ -137,7 +137,7 @@ open class RtpReportPayload : Encodable, Decodable {
                 TAG_SSRC -> ssrc = buffer.readLong()
                 TAG_CALL_ID -> callId = buffer.readCharSequence(length, Charset.defaultCharset()).toString()
                 TAG_CODEC_NAME -> codecName = buffer.readCharSequence(length, Charset.defaultCharset()).toString()
-                TAG_CUMULATIVE -> cumulative = buffer.readBoolean()
+                TAG_RECORDED -> recorded = buffer.readBoolean()
                 TAG_EXPECTED_PACKET_COUNT -> expectedPacketCount = buffer.readInt()
                 TAG_RECEIVED_PACKET_COUNT -> receivedPacketCount = buffer.readInt()
                 TAG_LOST_PACKET_COUNT -> lostPacketCount = buffer.readInt()

--- a/src/test/kotlin/io/sip3/commons/domain/payload/RtpHeaderPayloadTest.kt
+++ b/src/test/kotlin/io/sip3/commons/domain/payload/RtpHeaderPayloadTest.kt
@@ -30,9 +30,10 @@ class RtpHeaderPayloadTest {
             ssrc = 3
             timestamp = 4
             marker = true
+            recorded = true
         }
         val encoded = payload.encode()
-        assertEquals(22, encoded.capacity())
+        assertEquals(23, encoded.capacity())
 
         val decoded = RtpHeaderPayload().apply { decode(encoded) }
         payload.apply {
@@ -41,6 +42,7 @@ class RtpHeaderPayloadTest {
             assertEquals(ssrc, decoded.ssrc)
             assertEquals(timestamp, decoded.timestamp)
             assertEquals(marker, decoded.marker)
+            assertEquals(recorded, decoded.recorded)
         }
     }
 }

--- a/src/test/kotlin/io/sip3/commons/domain/payload/RtpReportPayloadTest.kt
+++ b/src/test/kotlin/io/sip3/commons/domain/payload/RtpReportPayloadTest.kt
@@ -172,9 +172,9 @@ class RtpReportPayloadTest {
             val decodedCodecName = codecNameBytes.toString(Charset.defaultCharset())
             assertEquals(codecName, decodedCodecName)
 
-            assertEquals(RtpReportPayload.TAG_CUMULATIVE, byteBuf.readByte().toInt())
+            assertEquals(RtpReportPayload.TAG_RECORDED, byteBuf.readByte().toInt())
             assertEquals(4, byteBuf.readShort())
-            assertEquals(cumulative, byteBuf.readBoolean())
+            assertEquals(recorded, byteBuf.readBoolean())
 
             assertEquals(RtpReportPayload.TAG_EXPECTED_PACKET_COUNT, byteBuf.readByte().toInt())
             assertEquals(7, byteBuf.readShort())


### PR DESCRIPTION
Removed: `cumulative` attribute